### PR TITLE
allow single events to be emitted from pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='statsd',
-    version='3.3.0.1',
+    version='3.3.0.2',
     description='A simple statsd client.',
     long_description=open('README.rst').read(),
     author='James Socol',

--- a/statsd/client/consistent_hashing.py
+++ b/statsd/client/consistent_hashing.py
@@ -31,8 +31,7 @@ class Pipeline(PipelineBase):
         self._maxudpsize = client._maxudpsize
 
     def _send(self):
-        data = self._stats.popleft()
-        stat = None
+        stat = data = self._stats.popleft()
         while self._stats:
             # Use popleft to preserve the order of the stats.
             stat = self._stats.popleft()


### PR DESCRIPTION
the first argument to ` self._client._after` is just used for picking the server to send the
events to and isn't added to the payload additionally

https://klaviyo.tpondemand.com/entity/44158-consistent_hashing-pipeline-skips-sending-if-only